### PR TITLE
exit early when $app is not an Application

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -12,6 +12,7 @@ $app = require 'public/index.php';
 
 if (empty($app) || !($app instanceof Application)) {
     echo 'Application not returned from index.php';
+	exit;
 }
 
 $app->getServiceManager()


### PR DESCRIPTION
When require did not return an instance of `Zend\Mvc\Application` for whatever reason, there is no use in trying to continue. So exit early

Output before:
```sh
> vendor/bin/console 
Application not returned from index.phpPHP Fatal error:  Uncaught Error: Call to a member function getServiceManager() on integer in /var/www/test/vendor/eth8505/zf-symfony-console/bin/console:17
Stack trace:
#0 {main}
  thrown in /var/www/test/vendor/eth8505/zf-symfony-console/bin/console on line 17
```